### PR TITLE
Issue 19 Implement Figma colour palettes and custom font styles

### DIFF
--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -19,7 +19,7 @@ const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <div className={`${fontMontserrat.variable} ${fontWorkSans}`}>
+    <div className={`${fontMontserrat.variable} ${fontWorkSans.variable}`}>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools initialIsOpen={false} />
         <Component {...pageProps} />

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -19,17 +19,11 @@ const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <>
-      <style jsx global>{`
-        :root {
-          --font-montserrat: ${fontMontserrat.style.fontFamily};
-          --font-worksans: ${fontWorkSans.style.fontFamily};
-        }
-      `}</style>
+    <div className={`${fontMontserrat.variable} ${fontWorkSans}`}>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools initialIsOpen={false} />
         <Component {...pageProps} />
       </QueryClientProvider>
-    </>
+    </div>
   );
 }

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -12,7 +12,7 @@ const fontMontserrat = Montserrat({
 
 const fontWorkSans = Work_Sans({
   subsets: ["latin"],
-  variable: "--font-montserrat",
+  variable: "--font-worksans",
 });
 
 const queryClient = new QueryClient();

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -3,14 +3,33 @@ import "@/styles/globals.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import type { AppProps } from "next/app";
+import { Montserrat, Work_Sans } from "next/font/google";
+
+const fontMontserrat = Montserrat({
+  subsets: ["latin"],
+  variable: "--font-montserrat",
+});
+
+const fontWorkSans = Work_Sans({
+  subsets: ["latin"],
+  variable: "--font-montserrat",
+});
 
 const queryClient = new QueryClient();
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <QueryClientProvider client={queryClient}>
-      <ReactQueryDevtools initialIsOpen={false} />
-      <Component {...pageProps} />
-    </QueryClientProvider>
+    <>
+      <style jsx global>{`
+        :root {
+          --font-montserrat: ${fontMontserrat.style.fontFamily};
+          --font-worksans: ${fontWorkSans.style.fontFamily};
+        }
+      `}</style>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <Component {...pageProps} />
+      </QueryClientProvider>
+    </>
   );
 }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -25,8 +25,8 @@ export default function Home() {
       )}
     >
       {/* Delete after style testing */}
-      <p className="subtitle">subtitle style test</p>
-      <h1 className="text-3xl text-primary">Test title</h1>
+      <p className="subtitle text-primary">subtitle with primary colour</p>
+      <h1 className="title-large text-dark">Test Title</h1>
       <Button onClick={() => setClicked(true)}>
         {isLoading ? "Loading" : "Ping"}
       </Button>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -24,6 +24,8 @@ export default function Home() {
         fontSans.variable,
       )}
     >
+      {/* Delete after style testing */}
+      <p className="subtitle">subtitle style test</p>
       <h1 className="text-3xl text-primary">Test title</h1>
       <Button onClick={() => setClicked(true)}>
         {isLoading ? "Loading" : "Ping"}

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -70,4 +70,33 @@
   body {
     @apply bg-background text-foreground;
   }
+  .title-large {
+    @apply font-montserrat text-[60px] font-semibold leading-[1em];
+  }
+  .title {
+    @apply font-montserrat text-[46px] font-semibold leading-[1.15em];
+  }
+  .subtitle {
+    @apply font-montserrat text-[30px] font-bold leading-[1.15em];
+  }
+  .medium-lg {
+    @apply font-montserrat text-[24px] font-[500];
+  }
+  /* button */
+  .medium-md {
+    @apply font-montserrat text-[18px] font-[500];
+  }
+  /* navbar */
+  .medium-sm {
+    @apply font-montserrat text-[14px] font-bold;
+  }
+  .body-lg {
+    @apply font-worksans text-[22px] font-[500];
+  }
+  .body-sm {
+    @apply font-worksans text-[17px] font-[500];
+  }
+  .caption {
+    @apply font-worksans text-[16px] font-normal;
+  }
 }

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -21,6 +21,8 @@ const config = {
     extend: {
       fontFamily: {
         sans: ["var(--font-sans)", ...fontFamily.sans],
+        montserrat: ["var(--font-montserrat)", ...fontFamily.sans],
+        worksans: ["var(--font-worksans)", ...fontFamily.sans],
       },
       colors: {
         border: "hsl(var(--border))",

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -25,19 +25,21 @@ const config = {
         worksans: ["var(--font-worksans)", ...fontFamily.sans],
       },
       colors: {
-        border: "hsl(var(--border))",
+        primary: "#F89200",
+        secondary: "#54595F",
+        text: "#7A7A7A",
+        light: "#F4F4F4",
+        dark: "#212529",
+        bgDark: "#151518",
+        bgLight: "F3F3F3",
+        bgCard: "#33302D",
+        border: "#4E4846",
+        buttonDark: "#030304",
+        // pre-set colors, to be deleted
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",


### PR DESCRIPTION
## Change Summary
Added the following from the Figma designs for consistency throughout the front end development:
- google font links/integration for Montserrat & Work Sans
- custom text styles
- colour palette

## Other Information
Please feel free to comment here or edit this branch if the naming conventions are off or if you believe refactoring is needed for any of the custom styles (e.g. would they be better under utilities? etc)

# Related issue

- Resolve #19