### PR TITLE
Match Detail API added:

### DIFF
--- a/server/api/details/apps.py
+++ b/server/api/details/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DetailsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "api.details"

--- a/server/api/details/serializers.py
+++ b/server/api/details/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+from api.match.models import MatchResult
+
+
+class MatchResultSerializer(serializers.ModelSerializer):
+    match_id = serializers.IntegerField(source='match.match_id')
+
+    class Meta:
+        model = MatchResult
+        fields = '__all__'

--- a/server/api/details/tests.py
+++ b/server/api/details/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase  # noqa
+
+# Create your tests here.

--- a/server/api/details/urls.py
+++ b/server/api/details/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from .views import MatchResultsByGroup, MatchResultsByStage, get_groups, get_stages
+
+urlpatterns = [
+    path('group_stage/<int:groupid>/', MatchResultsByGroup.as_view(), name='match-results-by-group'),
+    path('knockout_stage/<int:stageid>/', MatchResultsByStage.as_view(), name='match-results-by-stage'),
+    path('groups/', get_groups, name='get-groups'),
+    path('stages/', get_stages, name='get-stages')
+]

--- a/server/api/details/views.py
+++ b/server/api/details/views.py
@@ -1,0 +1,43 @@
+from collections import defaultdict
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from django.http import JsonResponse
+from api.match.models import MatchResult, Match
+from .serializers import MatchResultSerializer
+
+
+class MatchResultsByGroup(APIView):
+    def get(self, request, groupid):
+        queryset = MatchResult.objects.filter(match__group_id=groupid)
+        serializer = MatchResultSerializer(queryset, many=True)
+
+        grouped_data = defaultdict(list)
+        for item in serializer.data:
+            grouped_data[item['match_id']].append(item)
+
+        return Response(list(grouped_data.values()))
+
+
+class MatchResultsByStage(APIView):
+    def get(self, request, stageid):
+        if stageid == 0:
+            return Response("This route is not for group stage, use group_stage/<int:groupid>/ instead")
+
+        queryset = MatchResult.objects.filter(match__stage_id=stageid)
+        serializer = MatchResultSerializer(queryset, many=True)
+
+        grouped_data = defaultdict(list)
+        for item in serializer.data:
+            grouped_data[item['match_id']].append(item)
+
+        return Response(list(grouped_data.values()))
+
+
+def get_groups(request):
+    group_ids = sorted(list(Match.objects.values_list('group_id', flat=True).distinct()))
+    return JsonResponse(group_ids, safe=False)
+
+
+def get_stages(request):
+    stage_ids = sorted(list(Match.objects.values_list('stage_id', flat=True).distinct()))
+    return JsonResponse(stage_ids, safe=False)

--- a/server/api/settings.py
+++ b/server/api/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
     "api.healthcheck",
     "api.match",
     "api.sponsor.apps.SponsorConfig",
+    "api.details"
 ]
 
 MIDDLEWARE = [

--- a/server/api/urls.py
+++ b/server/api/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("api/healthcheck/", include(("api.healthcheck.urls"))),
     path("api/match/", include(("api.match.urls"))),
     path("api/sponsor/", include(("api.sponsor.urls"))),
+    path("api/details/", include(("api.details.urls"))),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## API Routes for dropdown
- api/details/stages: get a list of stages for the dropdown
- api/details/groups: get a list of groups for the dropdown

## API Routes for group/knockout stage details
- api/details/group_stage/<int:groupid>: get table objects filtered by group
- api/details/knockout_stage/<int:stageid>: get knockout stage objects filtered by stageid (cant take 0 as a stageid since it is used for group stage)

## How the data is structured for group/knockout stage: 
```bash
[
    [
        {team1 row details}, # one team row
        {team2 row details},
    ], # one table
    [
        {team2 row details},
        {team3 row details},
    ]
]
```

# Related issue

- Resolve #41