### PR TITLE
Fix leaderboard dropdown styling

### DIFF
--- a/client/src/components/ui/Leaderboard/List.tsx
+++ b/client/src/components/ui/Leaderboard/List.tsx
@@ -142,7 +142,7 @@ export default function List({ data = [] }) {
           <div className="relative">
             <label
               htmlFor="groupSelect"
-              className="body-sm absolute -top-2 left-3 z-10 bg-white px-1 text-xs"
+              className="body-sm bg-white pr-2 text-xs"
             >
               Select Group:
             </label>


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
Fix styling

Change from: 
<img width="925" height="525" alt="image" src="https://github.com/user-attachments/assets/06ed3db5-c06a-4020-a044-05ebcc0d39c1" />

to:
<img width="964" height="642" alt="image" src="https://github.com/user-attachments/assets/22ed351e-e048-435b-9cc6-43f4e6afe5a8" />

